### PR TITLE
fix for null history case

### DIFF
--- a/lambdas/qna_bot_qbusiness_lambdahook/src/lambdahook.py
+++ b/lambdas/qna_bot_qbusiness_lambdahook/src/lambdahook.py
@@ -19,21 +19,19 @@ qbusiness_client = boto3.client(
 
 def get_amazonq_response(prompt, context, amazonq_userid):
     print(f"get_amazonq_response: prompt={prompt}, app_id={AMAZONQ_APP_ID}, context={context}")
+    input = {
+        "applicationId": AMAZONQ_APP_ID,
+        "userMessage": prompt,
+        "userId": amazonq_userid
+    }
     if context:
-        input = {
-            "applicationId": AMAZONQ_APP_ID,
-            "conversationId": context["conversationId"],
-            "parentMessageId": context["parentMessageId"],
-            "userMessage": prompt,
-            "userId": amazonq_userid
-        }
+        if context["conversationId"]:
+            input["conversationId"] = context["conversationId"]
+        if context["parentMessageId"]:
+            input["parentMessageId"] = context["parentMessageId"]
     else:
-        input = {
-            "applicationId": AMAZONQ_APP_ID,
-            "userMessage": prompt,
-            "userId": amazonq_userid,
-            "clientToken": str(uuid.uuid4())
-        }
+        input["clientToken"] = str(uuid.uuid4())
+
     print("Amazon Q Input: ", json.dumps(input))
     try:
         resp = qbusiness_client.chat_sync(**input)


### PR DESCRIPTION
*Issue #, if available:* Q Business Hook Null History Case Bug #20

*Description of changes:*
When there is no previous history context["conversationId"] and context["parentMessageId"] are both `null`. I simply modified this so these fields are added conditionally if they are truthy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
