### PR TITLE
Add support for Claude Haiku and Opus models on Bedrock

### DIFF
--- a/lambdas/bedrock-embeddings-and-llm/template.yml
+++ b/lambdas/bedrock-embeddings-and-llm/template.yml
@@ -12,7 +12,7 @@ Parameters:
 
   LLMModelId:
     Type: String
-    Default: anthropic.claude-instant-v1
+    Default: anthropic.claude-3-haiku-20240307-v1:0
     AllowedValues:
       - amazon.titan-text-express-v1
       - amazon.titan-text-lite-v1
@@ -21,7 +21,9 @@ Parameters:
       - anthropic.claude-instant-v1
       - anthropic.claude-v2
       - anthropic.claude-v2:1
+      - anthropic.claude-3-haiku-20240307-v1:0
       - anthropic.claude-3-sonnet-20240229-v1:0
+      - anthropic.claude-3-opus-20240229-v1:0
       - cohere.command-text-v14
       - cohere.command-light-text-v14
       - meta.llama2-13b-chat-v1


### PR DESCRIPTION
Add support for Claude Haiku and Opus models on Bedrock 
 - change default LLMModelId to Claude-3 Haiku as it is cheaper and more performant than claude-instant-v1

__*Opus model looks like it is available starting today, staging PR but still need to test. Please wait to merge until testing has been confirmed.*__

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
