### PR TITLE
Add IDC Integration for QBusiness

### DIFF
--- a/lambdas/qna_bot_qbusiness_lambdahook/src/lambdahook.py
+++ b/lambdas/qna_bot_qbusiness_lambdahook/src/lambdahook.py
@@ -1,28 +1,24 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-
+import base64
 import json
 import os
+import random
+import string
 import uuid
 import boto3
 
 AMAZONQ_APP_ID = os.environ.get("AMAZONQ_APP_ID")
 AMAZONQ_REGION = os.environ.get("AMAZONQ_REGION") or os.environ["AWS_REGION"]
-AMAZONQ_ENDPOINT_URL = os.environ.get("AMAZONQ_ENDPOINT_URL") or f'https://qbusiness.{AMAZONQ_REGION}.api.aws'  
+AMAZONQ_ENDPOINT_URL = os.environ.get("AMAZONQ_ENDPOINT_URL") or f'https://qbusiness.{AMAZONQ_REGION}.api.aws'
 print("AMAZONQ_ENDPOINT_URL:", AMAZONQ_ENDPOINT_URL)
 
-qbusiness_client = boto3.client(
-    service_name="qbusiness", 
-    region_name=AMAZONQ_REGION,
-    endpoint_url=AMAZONQ_ENDPOINT_URL
-)
 
-def get_amazonq_response(prompt, context, amazonq_userid, attachments):
+def get_amazonq_response(prompt, context, attachments, qbusiness_client):
     print(f"get_amazonq_response: prompt={prompt}, app_id={AMAZONQ_APP_ID}, context={context}")
     input = {
         "applicationId": AMAZONQ_APP_ID,
-        "userMessage": prompt,
-        "userId": amazonq_userid
+        "userMessage": prompt
     }
     if context:
         if context["conversationId"]:
@@ -31,7 +27,7 @@ def get_amazonq_response(prompt, context, amazonq_userid, attachments):
             input["parentMessageId"] = context["parentMessageId"]
     else:
         input["clientToken"] = str(uuid.uuid4())
-    
+
     if attachments:
         input["attachments"] = attachments
 
@@ -43,12 +39,13 @@ def get_amazonq_response(prompt, context, amazonq_userid, attachments):
         resp = {
             "systemMessage": "Amazon Q Error: " + str(e)
         }
-    print("Amazon Q Response: ", json.dumps(resp))
+    print("Amazon Q Response: ", json.dumps(resp, default=str))
     return resp
+
 
 def get_settings_from_lambdahook_args(event):
     lambdahook_settings = {}
-    lambdahook_args_list = event["res"]["result"].get("args",[])
+    lambdahook_args_list = event["res"]["result"].get("args", [])
     print("LambdaHook args: ", lambdahook_args_list)
     if len(lambdahook_args_list):
         try:
@@ -58,18 +55,10 @@ def get_settings_from_lambdahook_args(event):
             print("..continuing")
     return lambdahook_settings
 
-def get_user_email(event):
-    isVerifiedIdentity = event["req"]["_userInfo"].get("isVerifiedIdentity")
-    if not isVerifiedIdentity:
-        print("User is not verified identity")
-        return "Bot_user_not_verified"
-    user_email = event["req"]["_userInfo"].get("Email")
-    print(f"using verified bot user email as user id: {user_email}")
-    return user_email
 
 def get_args_from_lambdahook_args(event):
     parameters = {}
-    lambdahook_args_list = event["res"]["result"].get("args",[])
+    lambdahook_args_list = event["res"]["result"].get("args", [])
     print("LambdaHook args: ", lambdahook_args_list)
     if len(lambdahook_args_list):
         try:
@@ -79,6 +68,7 @@ def get_args_from_lambdahook_args(event):
             print("..continuing")
     return parameters
 
+
 def getS3File(s3Path):
     if s3Path.startswith("s3://"):
         s3Path = s3Path[5:]
@@ -87,8 +77,9 @@ def getS3File(s3Path):
     obj = s3.Object(bucket, key)
     return obj.get()['Body'].read()
 
+
 def getAttachments(event):
-    userFilesUploaded = event["req"]["session"].get("userFilesUploaded",[])
+    userFilesUploaded = event["req"]["session"].get("userFilesUploaded", [])
     attachments = []
     for userFile in userFilesUploaded:
         print(f"getAttachments: userFile={userFile}")
@@ -97,16 +88,17 @@ def getAttachments(event):
             "name": userFile["fileName"]
         })
     # delete userFilesUploaded from session
-    event["res"]["session"].pop("userFilesUploaded",None)
+    event["res"]["session"].pop("userFilesUploaded", None)
     return attachments
+
 
 def format_response(event, amazonq_response):
     # get settings, if any, from lambda hook args
     # e.g: {"Prefix":"<custom prefix heading>", "ShowContext": False}
     lambdahook_settings = get_settings_from_lambdahook_args(event)
-    prefix = lambdahook_settings.get("Prefix","Amazon Q Answer:")
-    showContextText = lambdahook_settings.get("ShowContextText",True)
-    showSourceLinks = lambdahook_settings.get("ShowSourceLinks",True)
+    prefix = lambdahook_settings.get("Prefix", "Amazon Q Answer:")
+    showContextText = lambdahook_settings.get("ShowContextText", True)
+    showSourceLinks = lambdahook_settings.get("ShowSourceLinks", True)
     # set plaintext, markdown, & ssml response
     if prefix in ["None", "N/A", "Empty"]:
         prefix = None
@@ -118,21 +110,22 @@ def format_response(event, amazonq_response):
         markdown = f"**{prefix}**\n\n{markdown}"
     if showContextText:
         contextText = ""
-        for source in amazonq_response.get("sourceAttributions",[]):
-            title = source.get("title","title missing")
-            snippet = source.get("snippet","snippet missing")
+        for source in amazonq_response.get("sourceAttributions", []):
+            title = source.get("title", "title missing")
+            snippet = source.get("snippet", "snippet missing")
             url = source.get("url")
             if url:
                 contextText = f'{contextText}<br><a href="{url}">{title}</a>'
             else:
                 contextText = f'{contextText}<br><u><b>{title}</b></u>'
-            contextText = f"{contextText}<br>{snippet}\n"
+            # Returning too large of a snippet can break QnABot by exceeding the event payload size limit
+            contextText = f"{contextText}<br>{snippet}\n"[:5000]
         if contextText:
             markdown = f'{markdown}\n<details><summary>Context</summary><p style="white-space: pre-line;">{contextText}</p></details>'
     if showSourceLinks:
         sourceLinks = []
-        for source in amazonq_response.get("sourceAttribution",[]):
-            title = source.get("title","link (no title)")
+        for source in amazonq_response.get("sourceAttribution", []):
+            title = source.get("title", "link (no title)")
             url = source.get("url")
             if url:
                 sourceLinks.append(f'<a href="{url}">{title}</a>')
@@ -153,26 +146,89 @@ def format_response(event, amazonq_response):
         "parentMessageId": amazonq_response.get("systemMessageId")
     }
     event["res"]["session"]["qnabotcontext"]["amazonq_context"] = amazonq_context
-    #TODO - can we determine when Amazon Q has a good answer or not?
-    #For now, always assume it's a good answer.
-    #QnAbot sets session attribute qnabot_gotanswer True when got_hits > 0
+    # TODO - can we determine when Amazon Q has a good answer or not?
+    # For now, always assume it's a good answer.
+    # QnAbot sets session attribute qnabot_gotanswer True when got_hits > 0
     event["res"]["got_hits"] = 1
     return event
+
+
+def get_idc_iam_credentials(jwt):
+    sso_oidc_client = boto3.client('sso-oidc')
+    idc_sso_resp = sso_oidc_client.create_token_with_iam(
+        clientId=os.environ.get("IDC_CLIENT_ID"),
+        grantType="urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion=jwt,
+    )
+
+    print(idc_sso_resp)
+    idc_sso_id_token_jwt = json.loads(base64.b64decode(idc_sso_resp['idToken'].split('.')[1] + '==').decode())
+
+    sts_context = idc_sso_id_token_jwt["sts:identity_context"]
+    sts_client = boto3.client('sts')
+    session_name = "qbusiness-idc-" + "".join(
+        random.choices(string.ascii_letters + string.digits, k=32)
+    )
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=os.environ.get("AMAZONQ_ROLE_ARN"),
+        RoleSessionName=session_name,
+        ProvidedContexts=[{
+            "ProviderArn": "arn:aws:iam::aws:contextProvider/IdentityCenter",
+            "ContextAssertion": sts_context
+        }]
+    )
+    creds_object = assumed_role_object['Credentials']
+
+    return creds_object
+
 
 def lambda_handler(event, context):
     print("Received event: %s" % json.dumps(event))
     args = get_args_from_lambdahook_args(event)
-    # prompt set from args, or from req.question if not specified in args.
-    userInput = args.get("Prompt", event["req"]["question"])
-    qnabotcontext = event["req"]["session"].get("qnabotcontext",{})
-    amazonq_context = qnabotcontext.get("amazonq_context",{})
+    # prompt set from args, or from the original query if not specified in args.
+    userInput = event["req"]["llm_generated_query"]["orig"]
+    qnabotcontext = event["req"]["session"].get("qnabotcontext", {})
+    amazonq_context = qnabotcontext.get("amazonq_context", {})
     attachments = getAttachments(event)
-    amazonq_userid = os.environ.get("AMAZONQ_USER_ID")
-    if not amazonq_userid:
-        amazonq_userid = get_user_email(event)
+
+    # Get the IDC IAM credentials
+    # Parse session JWT token to get the jti
+    token = (event['req']['session']['idtokenjwt'])
+    decoded_token = json.loads(base64.b64decode(token.split('.')[1] + '==').decode())
+    jti = decoded_token['jti']
+
+    dynamo_resource = boto3.resource('dynamodb')
+    dynamo_table = dynamo_resource.Table(os.environ.get('DYNAMODB_CACHE_TABLE_NAME'))
+
+    kms_client = boto3.client('kms')
+    kms_key_id = os.environ.get("KMS_KEY_ID")
+
+    # Check if JTI exists in caching DB
+    response = dynamo_table.get_item(Key={'jti': jti})
+
+    if 'Item' in response:
+        creds = json.loads((kms_client.decrypt(
+            KeyId=kms_key_id,
+            CiphertextBlob=response['Item']['Credentials'].value))['Plaintext'])
     else:
-        print(f"using configured default user id: {amazonq_userid}")
-    amazonq_response = get_amazonq_response(userInput, amazonq_context, amazonq_userid, attachments)
+        creds = get_idc_iam_credentials(token)
+        exp = creds['Expiration'].timestamp()
+        creds.pop('Expiration')
+        # Encrypt the credentials and store them in the caching DB
+        encrypted_creds = \
+            kms_client.encrypt(KeyId=kms_key_id,
+                               Plaintext=bytes(json.dumps(creds).encode()))['CiphertextBlob']
+        dynamo_table.put_item(Item={'jti': jti, 'ExpiresAt': int(exp), 'Credentials': encrypted_creds})
+
+    # Assume the qbusiness role with the IDC IAM credentials to create the qbusiness client
+    assumed_session = boto3.Session(
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken']
+    )
+
+    qbusiness_client = assumed_session.client("qbusiness")
+    amazonq_response = get_amazonq_response(userInput, amazonq_context, attachments, qbusiness_client)
     event = format_response(event, amazonq_response)
     print("Returning response: %s" % json.dumps(event))
     return event

--- a/lambdas/qna_bot_qbusiness_lambdahook/template.yml
+++ b/lambdas/qna_bot_qbusiness_lambdahook/template.yml
@@ -10,6 +10,22 @@ Parameters:
     AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9-]{35}$'
     Description: Amazon Q Application ID (copy from AWS console)
 
+  AmazonQRoleARN:
+    Type: String
+    Description: Amazon Q Business Role ARN to Assume (copy from AWS console)
+
+  IDCClientId:
+    Type: String
+    Description: Amazon Q Business IDC Client ID (copy from AWS console)
+
+  DynamoDBTableName:
+    Type: String
+    Description: DynamoDB Table Name used for caching QBusiness credentials (copy from AWS console)
+
+  KMSKeyId:
+    Type: String
+    Description: KMS Key ID used for encrypting and decrypting QBusiness credentials (copy from AWS console)
+
   AmazonQUserId:
     Type: String
     Default: ""
@@ -81,6 +97,10 @@ Resources:
         Variables:
           AWS_DATA_PATH: /opt/model
           AMAZONQ_APP_ID: !Ref AmazonQAppId
+          AMAZONQ_ROLE_ARN: !Ref AmazonQRoleARN
+          DYNAMODB_CACHE_TABLE_NAME: !Ref DynamoDBTableName
+          KMS_KEY_ID: !Ref KMSKeyId
+          IDC_CLIENT_ID: !Ref IDCClientId
           AMAZONQ_USER_ID: !Ref AmazonQUserId
           AMAZONQ_REGION: !Ref AmazonQRegion
           AMAZONQ_ENDPOINT_URL: !Ref AmazonQEndpointUrl


### PR DESCRIPTION
*Description of changes:*

This pull request adds functionality to enable integration with the QBusiness Identity Center (IDC) as well as caching of credentials in DynamoDB.

The following changes were made:

- Added code to call create_token_with_iam to generate a session based on assuming an IAM role with permissions to QBusiness. This allows the application to integrate with IDC and generate temporary security credentials that can be reused to call the QBusiness chatsync operation.
- Added a reference to a new DynamoDB table to cache credentials generated via the IDC until their expiration time, including encryption and decryption of the credentials object using KMS.  Because the passed JWT can only be used once unless refreshed, caching allows the plugin to re-use the generated credentials until their expiration
- Removed references in the lambdahook to specific emails, as QBusiness no longer requires this parameter
- Added environment variables to the template to account for the required QBusiness IAM Role ARN, IDC Client, DynamoDB table, and KMS key.
- Modified the prompt being sent to QBusiness chatsync. QBusiness conducts it's own query disambiguation, so it is more performant to send the original query string.
- Modified the allowed returned snippet length. If showContextText is true, QBusiness will return the entire snippet to the lambda. Too many snippets, or snippets that are too long can exceed the allowable returned payload. This number should be tuned to the number, type, and content of returned data.

Please let me know if any part of these changes require further explanation or modification prior to merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
